### PR TITLE
feat(dev-tips): Making dev tips grid autofill

### DIFF
--- a/packages/gatsby-theme-dev-tips/src/components/dev-tip-collection.js
+++ b/packages/gatsby-theme-dev-tips/src/components/dev-tip-collection.js
@@ -16,7 +16,7 @@ export default props => {
         sx={{
           display: "grid",
           gridGap: "1rem",
-          gridTemplateColumns: ["1fr", "1fr 1fr", "1fr 1fr 1fr"]
+          gridTemplateColumns: "repeat(auto-fill, minmax(378px, 1fr))"
         }}
       >
         {props.data.allDevTip.nodes.map(({ id, title, tweet, body }) => (


### PR DESCRIPTION
This switches from a static set of grids to a dynamic one which it will keep adding more components of the size of each tip until it needs to wrap to the next row