### PR TITLE
Add in var crypto = require("crypto")

### DIFF
--- a/www/content/posts/applying-theme-options-using-custom-configuration-nodes.mdx
+++ b/www/content/posts/applying-theme-options-using-custom-configuration-nodes.mdx
@@ -25,6 +25,8 @@ breadcrumbSeparator: String
 Then in `sourceNodes` we'll talk the options configured with defaults and inject them into the node system as a node.
 
 ```js title=gatsby-node.js
+var crypto = require("crypto")
+
 exports.sourceNodes = (
   { actions: { createNode }, schema },
   { basePath = `/`, homeText = `~`, breadcrumbSeparator = `/` }


### PR DESCRIPTION
When I followed these instructions I got a build error because I did not have a crypto, fixed it by including this line:

`var crypto = require("crypto")`

Added it in where I thought it made sense - feel free to accept this or do it another way entirely.  Just thought I would let you know this happened for me and this is what ended up fixing it.  I suspect you probably already had this in your gatsby-node.js file and didn't see the error because of this.