### PR TITLE
Let clicks pass through decorative element

### DIFF
--- a/packages/www/src/pages/index.js
+++ b/packages/www/src/pages/index.js
@@ -48,7 +48,8 @@ const LowerTilt = ({ color, flip, props }) => {
         width: "100%",
         overflow: "hidden",
         lineHeight: 0,
-        transform: `rotate(180deg)${flip ? " rotateY(180deg)" : ""}`
+        transform: `rotate(180deg)${flip ? " rotateY(180deg)" : ""}`,
+        pointerEvents: "none"
       }}
     >
       <svg


### PR DESCRIPTION
I found this trying to click one of your social buttons. The `LowerTilt` component was overlapping the buttons and blocking the clicks (checked in chrome and firefox). This change lets the clicks pass through to the buttons underneath.

<img width="1474" alt="Screenshot 2021-02-05 at 12 10 22" src="https://user-images.githubusercontent.com/381801/107033315-05d85980-67ad-11eb-90b8-b56d95dd092b.png">

