### PR TITLE
Fix channel id in YouTube link in homepage hero section.

### DIFF
--- a/packages/www/src/pages/index.js
+++ b/packages/www/src/pages/index.js
@@ -140,7 +140,7 @@ const Hero = props => (
         </li> */}
         <li class="">
           <SocialButton
-            href="https://www.youtube.com/channel/UCiSIL22pQRpc-8JNiYDFyzQ"
+            href="https://www.youtube.com/channel/UCiSIL42pQRpc-8JNiYDFyzQ"
             icon="youtube"
           >
             YouTube


### PR DESCRIPTION
This PR fixes a broken link to the YouTube channel in the hero section of the homepage.